### PR TITLE
Update the role name from WebBrowser to browser

### DIFF
--- a/conf.d/wgt/config.xml.in
+++ b/conf.d/wgt/config.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<widget xmlns="http://www.w3.org/ns/widgets" id="@PROJECT_NAME@" version="@PROJECT_VERSION@">
-  <name>@PROJECT_NAME@</name>
+<widget xmlns="http://www.w3.org/ns/widgets" id="browser" version="@PROJECT_VERSION@">
+  <name>browser</name>
   <icon src="@PROJECT_ICON@"/>
   <content src="@WIDGET_ENTRY_POINT@" type="@WIDGET_TYPE@"/>
   <description>@PROJECT_DESCRIPTION@</description>

--- a/runxdg.toml
+++ b/runxdg.toml
@@ -1,7 +1,8 @@
 [application]
 # role: identifier for WindowManager (used in layers.json)
 # e.g. role = "WebBrowser"
-role = "WebBrowser"
+#role = "WebBrowser"
+role = "browser"
 
 # launch by "POSIX"(fork/exec), "AFM_DBUS"(afm via dbus),  "AFM_WEBSOCKET"(afm via websockt)
 method = "POSIX"


### PR DESCRIPTION
It updates the role name to browser to sync with the role
name from layers.json and the application name to sync
with role name because runxdg compares it.

[SPEC-1889] Chromium is initially hidden when launched.
https://jira.automotivelinux.org/browse/SPEC-1889