### PR TITLE
Add window-size switch for AGL window size

### DIFF
--- a/runxdg.toml
+++ b/runxdg.toml
@@ -14,6 +14,7 @@ path = "/opt/chromium53/chrome"
 
 params = [
   "--in-process-gpu",
-  "--user-data-dir=/opt/chromium53/workdir"
+  "--user-data-dir=/opt/chromium53/workdir",
+  "--window-size=608,837"
 ]
 


### PR DESCRIPTION
It adds window-size switch for AGL window size. It couldn't get
the window size from window manager. So, this change passes the
argument for AGL window size.

[SPEC-1890] WebApp View Size doesn't fit the homescreen.
https://jira.automotivelinux.org/browse/SPEC-1890